### PR TITLE
Add install() commands to CMake, lower min C++ standard to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,33 @@
 cmake_minimum_required(VERSION 3.16)
-
-project(spdlog_setup
-    LANGUAGES CXX)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+project(spdlog_setup VERSION 1.1.1 LANGUAGES CXX)
 
 find_package(spdlog REQUIRED CONFIG)
 find_package(fmt REQUIRED CONFIG)
 find_package(cpptoml REQUIRED CONFIG)
 
+option(SPDLOG_SETUP_SPDLOG_HEADER_ONLY "Use header-only version of spdlog" ON)
+option(SPDLOG_SETUP_FMT_HEADER_ONLY "Use header-only version of fmt" ON)
+option(SPDLOG_SETUP_BUILD_TESTS "Build spdlog_setup tests" ON)
+
 # spdlog_setup
 add_library(spdlog_setup INTERFACE)
-target_include_directories(spdlog_setup INTERFACE include)
-target_link_libraries(spdlog_setup INTERFACE spdlog::spdlog_header_only cpptoml fmt::fmt-header-only)
+target_include_directories(spdlog_setup INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_compile_features(spdlog_setup INTERFACE cxx_std_14)
+
+target_link_libraries(spdlog_setup INTERFACE cpptoml)
+if (SPDLOG_SETUP_SPDLOG_HEADER_ONLY)
+    target_link_libraries(spdlog_setup INTERFACE spdlog::spdlog_header_only)
+else ()
+    target_link_libraries(spdlog_setup INTERFACE spdlog::spdlog)
+endif ()
+if (SPDLOG_SETUP_FMT_HEADER_ONLY)
+    target_link_libraries(spdlog_setup INTERFACE fmt::fmt-header-only)
+else ()
+    target_link_libraries(spdlog_setup INTERFACE fmt::fmt)
+endif ()
 
 # spdlog_setup_sources (for IDEs)
 if (XCODE OR MSVC)
@@ -26,7 +39,6 @@ if (XCODE OR MSVC)
 endif ()
 
 # Tests
-option(SPDLOG_SETUP_BUILD_TESTS "Build spdlog_setup tests" ON)
 if (SPDLOG_SETUP_BUILD_TESTS)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
@@ -48,3 +60,32 @@ if (SPDLOG_SETUP_BUILD_TESTS)
   include(Catch)
   catch_discover_tests(spdlog_setup_tests)
 endif ()
+
+
+# Installation
+install(DIRECTORY include/spdlog_setup DESTINATION include)
+
+install(TARGETS spdlog_setup EXPORT spdlog_setup_targets)
+install(EXPORT spdlog_setup_targets
+    FILE spdlog_setup-targets.cmake
+    NAMESPACE spdlog_setup::
+    DESTINATION lib/cmake/spdlog_setup
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/spdlog_setup-config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/spdlog_setup-config.cmake"
+    INSTALL_DESTINATION lib/cmake/spdlog_setup
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+write_basic_package_version_file(
+    "spdlog_setup-config-version.cmake"
+    VERSION ${spdlog_setup_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/spdlog_setup-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/spdlog_setup-config-version.cmake"
+    DESTINATION lib/cmake/spdlog_setup
+)

--- a/cmake/spdlog_setup-config.cmake.in
+++ b/cmake/spdlog_setup-config.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/spdlog_setup-targets.cmake")
+
+include(CMakeFindDependencyMacro)
+find_dependency(spdlog REQUIRED CONFIG)
+find_dependency(fmt REQUIRED CONFIG)
+find_dependency(cpptoml REQUIRED CONFIG)
+
+set_and_check(spdlog_setup_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
+set(spdlog_setup_LIBRARIES spdlog_setup::spdlog_setup)

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.52.0"
 
 class SpdlogSetupConan(ConanFile):
     name = "spdlog_setup"
-    version = "1.1.0"
+    version = "1.1.1"
     description = "Setup spdlog via a TOML config file"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
@@ -20,14 +20,14 @@ class SpdlogSetupConan(ConanFile):
     topics = ('spdlog', 'logging', 'header-only', 'TOML', 'cpptoml')
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = "include/*", "test/*", "CMakeLists.txt"
+    exports_sources = "include/*", "test/*", "CMakeLists.txt", "cmake/*", "LICENSE"
     no_copy_source = True
     default_options = {"fmt/*:header_only": True,
                        "spdlog/*:header_only": True}
 
     @property
     def _min_cppstd(self):
-        return 17
+        return 14
 
     @property
     def _compilers_minimum_version(self):
@@ -43,12 +43,12 @@ class SpdlogSetupConan(ConanFile):
         cmake_layout(self)
 
     def build_requirements(self):
-        self.test_requires("catch2/3.3.2")
+        self.test_requires("catch2/3.6.0")
 
     def requirements(self):
-        self.requires("cpptoml/0.1.1", transitive_headers=True)
-        self.requires("spdlog/1.11.0", transitive_headers=True, transitive_libs=True)
-        self.requires("fmt/9.1.0", transitive_headers=True, transitive_libs=True)
+        self.requires("cpptoml/0.1.1")
+        self.requires("spdlog/1.14.1")
+        self.requires("fmt/10.2.1")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Restores the CMake config creation and `install()` commands from the original repo.

I would like to add this library as a Vcpkg package and a proper CMake installation setup is required for that.

I tested the `test_package` with C++14 and it built fine with the lower C++ standard.

Bumped the Conan dependency versions to get rid of conflicts. `transitive_headers` etc are not needed when `package_type = "header-library"` is set.

I tested the installed output with `test_package` and it worked fine.